### PR TITLE
allows swapping in and out of batching depending on data flow

### DIFF
--- a/fluvii/consumer/config.py
+++ b/fluvii/consumer/config.py
@@ -15,6 +15,7 @@ class ConsumerConfig(KafkaConfigBase, BaseSettings):
     batch_consume_max_count: int = 100
     batch_consume_max_empty_polls: Optional[int] = 2
     batch_consume_max_time_seconds: Optional[int] = 10
+    batch_consume_trigger_message_age_seconds: int = 5
     batch_consume_store_messages: bool = False
     heartbeat_timeout_ms: int = 4 * 60 // 2 * 1_000  # TODO document that this pairs with timeout_minutes
     message_singleton_max_mb: int = 2

--- a/fluvii/consumer/consumer.py
+++ b/fluvii/consumer/consumer.py
@@ -131,15 +131,28 @@ class TransactionalConsumer(Consumer):
                  ):
         super().__init__(urls, group_id, consume_topics_list, schema_registry=schema_registry, auto_subscribe=auto_subscribe,
                          client_auth_config=client_auth_config, settings_config=settings_config, metrics_manager=metrics_manager)
-        self._batch_time_elapse_start = None
         self._consume_max_time_secs = self._settings.batch_consume_max_time_seconds
         self._consume_max_count = self._settings.batch_consume_max_count
         self._consume_max_empty_polls = self._settings.batch_consume_max_empty_polls
         self._store_batch_messages = self._settings.batch_consume_store_messages
+        self._max_msg_secs_behind = self._settings.batch_consume_trigger_message_age_seconds
+        self._batch_consume = False
         self._init_attrs()
         self._reset_keep_consuming_trackers()
 
+    def _refresh_batch_consume_status(self):
+        """
+        This allows us to keep the consumer in a "batch" state until it reaches conditions where it likely no longer
+        needs to remain so
+        """
+        if self._batch_consume:
+            if self._consume_max_count and self._consume_message_count < self._consume_max_count:
+                self._batch_consume = False
+            else:
+
+
     def _reset_keep_consuming_trackers(self):
+        self._refresh_batch_consume_status()
         self._batch_time_elapse_start = None
         self._batch_remaining_empty_polls = self._consume_max_empty_polls
         self._consume_message_count = 0
@@ -160,8 +173,6 @@ class TransactionalConsumer(Consumer):
                 self._set_batch_start_time()
             seconds_elapsed = datetime.datetime.now().timestamp() - self._batch_time_elapse_start
             continue_consume = seconds_elapsed < self._consume_max_time_secs
-            if not continue_consume:
-                self._batch_time_elapse_start = None
         return continue_consume
 
     def _max_consume_count_continue(self, consume_multiplier=1):
@@ -169,8 +180,18 @@ class TransactionalConsumer(Consumer):
             return self._consume_message_count < (self._consume_max_count * consume_multiplier)
         return True
 
+    def _requires_batch_consuming(self):
+        if not self._batch_consume:
+            delta = int(datetime.datetime.timestamp(datetime.datetime.utcnow())) - int(self.message.timestamp()[1])
+            LOGGER.debug(f'Message is {delta} seconds old')
+            if delta > self._max_msg_secs_behind:
+                LOGGER.info(f"Message is at least {self._max_msg_secs_behind} minutes old. Switching to batch!")
+                self._batch_consume = True
+
     def _keep_consuming(self, consume_multiplier=1):
-        return self._batch_remaining_empty_polls and self._max_consume_count_continue(consume_multiplier=consume_multiplier) and self._max_consume_time_continue()
+        if self.message:  # if at least 1 message has already been consumed
+            return self._batch_consume and self._batch_remaining_empty_polls and self._max_consume_count_continue(consume_multiplier=consume_multiplier) and self._max_consume_time_continue()
+        return True
 
     def _mark_offset_start(self):
         if self.message.topic() not in self._batch_offset_starts:
@@ -214,6 +235,7 @@ class TransactionalConsumer(Consumer):
 
     def _handle_consumed_message(self):
         super()._handle_consumed_message()
+        self._requires_batch_consuming()
         self._mark_offset_start()
         self._mark_offset_end()
         self._consume_message_count += 1
@@ -255,7 +277,8 @@ class TransactionalConsumer(Consumer):
             try:
                 return super().consume(timeout=timeout)
             except NoMessageError:
-                self._batch_remaining_empty_polls -= 1
+                self._batch_remaining_empty_polls -= 1  # still useful in cases with multiple empty polls and no other consumption limitations
+                self._batch_consume = False
         LOGGER.info('Consumption attempts for this batch are finished.')
         self._reset_keep_consuming_trackers()
         raise FinishedTransactionBatch

--- a/fluvii/fluvii_app/rebalance_manager.py
+++ b/fluvii/fluvii_app/rebalance_manager.py
@@ -134,7 +134,7 @@ class TableRebalanceManager:
             if p.table_offset < p.lowwater:
                 LOGGER.debug('Adjusting table offset due to it being lower than the changelog lowwater')
                 p.table_offset = p.lowwater - 2  # -2 since the table marks the latest offset it has (which can never be the "last" offset since it's a marker), not which offset is next (aka how kafka tracks it)
-        LOGGER.info(f'note: tables are considered "current" if highwater - table_offset <=2: {[(p.partition, p.table_offset, p.highwater) for p in self._changelog_partitions]}')
+        LOGGER.info(f'NOTE: tables are considered "current" if (highwater - table_offset) <= 2')
         LOGGER.info(f'(table, table offset, highwater) list : {[(p.partition, p.table_offset, p.highwater) for p in self._changelog_partitions]}')
 
     def _set_partition_recovery_statuses(self):

--- a/fluvii/metrics/manager/metrics_manager.py
+++ b/fluvii/metrics/manager/metrics_manager.py
@@ -44,7 +44,7 @@ class MetricsManager:
     Creates and manages Metric instances and pushes their metrics
     """
 
-    def __init__(self, metrics_config=MetricsManagerConfig(), registry=CollectorRegistry(), pusher_cls=MetricsPusher, pusher_config=MetricsPusherConfig()):
+    def __init__(self, metrics_config=MetricsManagerConfig(), registry=CollectorRegistry(), pusher_cls=MetricsPusher, pusher_config=MetricsPusherConfig(), auto_init=False):
         """
         Initializes monitor and Metric classes
         """
@@ -58,7 +58,8 @@ class MetricsManager:
         self.new_metric('external_requests', description='Network calls to external services', additional_labels=['request_to', 'request_endpoint', 'request_type', 'is_bulk', 'status_code']),
         self.new_metric('seconds_behind', description='Elapsed time since the consumed message was originally produced')
 
-        self.pusher = pusher_cls(self.registry, pusher_config)
+        if auto_init:
+            self.pusher = pusher_cls(self.registry, pusher_config)
 
     def __getattr__(self, name):
         try:

--- a/fluvii/metrics/manager/metrics_manager.py
+++ b/fluvii/metrics/manager/metrics_manager.py
@@ -44,7 +44,7 @@ class MetricsManager:
     Creates and manages Metric instances and pushes their metrics
     """
 
-    def __init__(self, metrics_config=MetricsManagerConfig(), registry=CollectorRegistry(), pusher_cls=MetricsPusher, pusher_config=MetricsPusherConfig(), auto_init=False):
+    def __init__(self, metrics_config=MetricsManagerConfig(), registry=CollectorRegistry(), pusher_cls=MetricsPusher, pusher_config=MetricsPusherConfig()):
         """
         Initializes monitor and Metric classes
         """
@@ -58,8 +58,7 @@ class MetricsManager:
         self.new_metric('external_requests', description='Network calls to external services', additional_labels=['request_to', 'request_endpoint', 'request_type', 'is_bulk', 'status_code']),
         self.new_metric('seconds_behind', description='Elapsed time since the consumed message was originally produced')
 
-        if auto_init:
-            self.pusher = pusher_cls(self.registry, pusher_config)
+        self.pusher = pusher_cls(self.registry, pusher_config)
 
     def __getattr__(self, name):
         try:

--- a/fluvii/schema_registry/schema_registry.py
+++ b/fluvii/schema_registry/schema_registry.py
@@ -19,11 +19,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 class SchemaRegistry:
-    def __init__(self, url, auth_config=None):
+    def __init__(self, url, auth_config=None, auto_init=True):
         self.registry = None
         self.url = url
         self._auth = auth_config
-        self._init_registry()
+        if auto_init:
+            self._init_registry()
 
     def __getattr__(self, attr):
         """Note: this includes methods as well!"""


### PR DESCRIPTION
Basically, messages will now be handled as singletons (dictated by the consumer) until batching is required `_batch_consume=False`. This will help speed up processing during low data flow situations.

While in singleton mode, after every message consume, the consumer will check what the message delay is (now - msg timestamp). If the delta is ever greater than allowed configured setting `batch_consume_trigger_message_age_seconds`, then batch mode will be initiated via `_batch_consume=True`.

Once batch consuming, it will ever only be turned off either when:
a) No messages are consumed in a poll, or
b) the message count of a finalized batch does not meet the max batch count.

This is to avoid doing time delta checks every message when in batch mode, and it's pretty safe to assume you want to "catch up" as much as possible before going back to singleton mode.