### PR TITLE
have sqlite recover from a corrupt db

### DIFF
--- a/fluvii/fluvii_app/fluvii_table_app.py
+++ b/fluvii/fluvii_app/fluvii_table_app.py
@@ -100,6 +100,7 @@ class FluviiTableApp(FluviiApp):
                 try:
                     self._handle_recovery_message()
                 except FinishedTransactionBatch:
+                    self._producer.poll(0)
                     self._finalize_recovery_batch()
                     raise TransactionCommitted
         except TransactionCommitted:


### PR DESCRIPTION
Sometimes, thing just happen, and the sqlite dict becomes corrupt. Added a feature to automatically delete it and kill the application so that it will rebuild upon restart.

Also added a producer poll operation during table recovery so the logs do not get spammed with authentication errors during long recovery times with Oauth clients.